### PR TITLE
Removed improv to save space

### DIFF
--- a/.github/workflows/publish-firmware.yml
+++ b/.github/workflows/publish-firmware.yml
@@ -17,7 +17,7 @@ jobs:
         buderus-km271_en_8MB.factory.yaml
         buderus-km271_en_espidf.factory.yaml
       esphome-version: 2025.7.2
-      #combined-name: buderus-km271-wifi
+      combined-name: buderus-km271-wifi
       #### Modify above here to match your project ####
 
       release-summary: ${{ github.event.release.body }}

--- a/buderus-km271_en.factory.yaml
+++ b/buderus-km271_en.factory.yaml
@@ -1,0 +1,18 @@
+packages:
+  # Include all of the core configuration
+  core: !include buderus-km271_en.yaml
+
+esphome:
+  # This will allow for project identification,
+  # configuration and updates.
+  project:
+    #name: esphome.project-template
+    name: esphome.km271-wifi
+    version: dev # This will be replaced by the github workflows with the `release` version
+
+# This should point to the public location of the yaml file that will be adopted.
+# In this case it is the core yaml file that does not contain the extra things
+# that are provided by this factory yaml file as the user does not need these once adopted.
+dashboard_import:
+  package_import_url: github://the78mole/ESPhome-KM271-WiFi/blob/main/buderus-km271_en_espidf.yaml
+

--- a/buderus-km271_en.yaml
+++ b/buderus-km271_en.yaml
@@ -1,0 +1,465 @@
+# This is the configuration, I've put on the board.
+# If you apply voltage to it, the green LED D! serves as status led2
+# usually blinking with around 1 Hz. If you press button USER 1, it will
+# toggle green led D2.
+# To upload a new firmware, search for the "Fallback Hotspot" WiFi and
+# log in with password "Z8zfajgxVvNw". It could take up to a minute for
+# the fallack AP to be enabled when not able to connect to the "test"
+# wifi network. So, if status is blinking, give it a minute to show up.
+substitutions:
+  name: "km271-for-friends"
+
+esphome:
+  name: "${name}"
+  friendly_name: KM271 for friends
+  # Automatically add the mac address to the name
+  # so you can use a single firmware for all devices
+  name_add_mac_suffix: true
+
+  platformio_options:
+    upload_speed: 921600
+    #board_build.f_flash: 80000000L
+    #board_build.partitions: "default_8MB.csv
+    #upload_flash_size: "8MB"
+
+  # This will allow for (future) project identification,
+  # configuration and updates.
+  #project:
+  #  name: the78mole.km271-wifi
+  #  version: "1.0"
+
+esp32:
+  board: esp32dev
+  framework:
+    type: arduino
+
+# Enable logging
+logger:
+
+# Enable Home Assistant API
+api:
+
+ota:
+  platform: esphome
+#  password: "xxx"
+
+wifi:
+#  ssid: "test"
+#  password: "testtest"
+
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: "Fallback Hotspot"
+    password: "Z8zfajgxVvNw"
+
+#dashboard_import:
+#  package_import_url: github://the78mole/esphome_components/components/km271_wifi/km271-for-friends.yaml@main
+
+captive_portal:
+#  keep_user_credentials: true
+
+uart:
+  id: uart_bus
+  tx_pin: GPIO2
+  rx_pin: GPIO4
+  baud_rate: 2400
+
+external_components:
+#  - source:
+#      type: local
+#      path: my_components/components
+#    components: [ km271_wifi ]
+  - source: github://the78mole/esphome_components@main
+    components: [ km271_wifi ]
+ 
+status_led:
+  id: ledgn1
+  pin: 
+    number: GPIO21
+    inverted: true
+
+km271_wifi:
+  - id: budoil
+    uart_id: uart_bus
+
+binary_sensor:
+  - platform: gpio
+    id: improvble
+    name: "USER 2"
+    pin:
+      number: GPIO27
+      inverted: true
+      mode:
+        input: true
+        pullup: true
+
+# Above is all the "give-away hardware suggestion stuff"
+# It is the place for cleanup of to reduce flash footprint, like: 
+# improv, captive portal, dashboard_import,...)
+##################################################################
+
+##################################################################
+# Below is the real examle stuff
+
+  - platform: km271_wifi
+    # Betriebswerte 1 HC1
+    heating_circuit_1_switch_off_optimization:
+      name: "HC1 Switch-off Optimization"
+    heating_circuit_1_switch_on_optimization:
+      name: "HC1 Switch-on Optimization"
+    heating_circuit_1_automatic:
+      name: "HC1 Automatic"
+    heating_circuit_1_ww_priority_processing:
+      name: "HC1 Hot Water priority"
+    heating_circuit_1_screed_drying:
+      name: "HC1 Screed Drying"
+    heating_circuit_1_holiday:
+      name: "HC1 Holiday"
+    heating_circuit_1_antifreeze:
+      name: "HC1 Antifreeze"
+    heating_circuit_1_manually:
+      name: "HC1 Manual"
+    # Betriebswerte 1 HC1
+    heating_circuit_1_summer:
+      name: "HC1 Summer Mode"
+    heating_circuit_1_day:
+      name: "HC1 Day Mode"
+    heating_circuit_1_no_comm_with_rc:
+      name: "HC1 No Communication with Remote Controller"
+    heating_circuit_1_rc_faulty:
+      name: "HC1 Remote Controller Failure"
+    heating_circuit_1_flow_sensor_error:
+      name: "HC1 Flow Sensor Error"
+    heating_circuit_1_max_flow:
+      name: "HC1 Maximum Flow Time" #???
+    heating_circuit_1_external_fault_input:
+      name: "HC1 External Fault Input"
+    # Betriebswerte 2 HC2
+    heating_circuit_2_switch_off_optimization:
+      name: "HC2 Switch-off Optimization"
+    heating_circuit_2_switch_on_optimization:
+      name: "HC2 Switch-on Optimization"
+    heating_circuit_2_automatic:
+      name: "HC2 Automatic"
+    heating_circuit_2_ww_priority_processing:
+      name: "HC2 Hot Water priority"
+    heating_circuit_2_screed_drying:
+      name: "HC2 Screed Drying"
+    heating_circuit_2_holiday:
+      name: "HC2 Holiday"
+    heating_circuit_2_antifreeze:
+      name: "HC2 Antifreeze"
+    heating_circuit_2_manually:
+      name: "HC2 Manual"
+    # Betriebswerte 2 HC1
+    heating_circuit_2_summer:
+      name: "HC2 Summer Mode"
+    heating_circuit_2_day:
+      name: "HC2 Day Mode"
+    heating_circuit_2_no_comm_with_rc:
+      name: "HC2 No Communication with Remote Controller"
+    heating_circuit_2_rc_faulty:
+      name: "HC2 Remote Controller Failure"
+    heating_circuit_2_flow_sensor_error:
+      name: "HC2 Flow Sensor Error"
+    heating_circuit_2_max_flow:
+      name: "HC2 Maximum Flow Time" #???
+    heating_circuit_2_external_fault_input:
+      name: "HC2 External Fault Input"
+    # Betriebswerte 1 DHW
+    ww_automatic:
+      name: "DHW Automatic"
+    ww_disinfection:
+      name: "WW Disinfection"
+    ww_reload:
+      name: "DHW Reload"
+    ww_holiday:
+      name: "DHW Holiday"
+    ww_error_disinfection:
+      name: "DHW Disinfektion Error"
+    ww_error_sensor:
+      name: "DHW Sensor Error"
+    ww_error_stays_cold:
+      name: "DHW Error DHW Stays cold"
+    ww_error_anode:
+      name: "DHW Anode failure"
+    # Betriebswerte 2 DHW
+    ww_loading:
+      name: "DHW Loading"
+    ww_manually:
+      name: "DHW Manual"
+    ww_reloading:
+      name: "DHW Reloading"
+    ww_switch_off_optimization:
+      name: "DHW Switch-off Optimization"
+    ww_switch_on_optimization:
+      name: "DHW Switch-on Optimization"
+    ww_day_mode:
+      name: "DHW Day Mode"
+    ww_post_processing:
+      name: "DHW Night Mode"
+    ww_priority_processing:
+      name: "DHW Priority Switching"
+    # Kesselfehler
+    error_burner_malfunction:
+      name: "FBurner Failure"
+    error_boiler_sensor:
+      name: "Boiler Sensor Error"
+    error_additional_sensor:
+      name: "Additional Sensor Error"
+    error_boiler_stays_cold:
+      name: "Boiler Stays Cold"
+    error_exhaust_gas_sensor:
+      name: "Exhaust Gas Sensor Error"
+    error_exhaust_gas_over_limit:
+      name: "FExhaust Gas Over Limit Error"
+    error_safety_chain_released:
+      name: "Safety Chain Error"
+    error_external_disturbance:
+      name: "External Disturbances Error"
+    # Kesselbetrieb
+    boiler_emission_test:
+      name: "Boiler Emission Test"
+    boiler_1st_stage_operation:
+      name: "Boiler Operation 1st Stage"
+    boiler_protection:
+      name: "Boiler Protection"
+    boiler_under_operation:
+      name: "Boiler in Operation"
+    boiler_performance_free:
+      name: "Boiler Performance Free"
+    boiler_performance_high:
+      name: "Boiler Performance High"
+    boiler_2st_stage_operation:
+      name: "Boiler Operation 2nd Stage"
+    boiler_actuation:
+      name: "Burner Control"
+  #Alarmstatus
+    alarm_exhaust_gas_sensor:
+      name: "Exhaust Gas Sensor Alarm"
+    alarm_boiler_flow_sensor:
+      name: "Boiler Flow Sensor Alarm"
+    alarm_burner:
+      name: "Burner Alarm"
+    alarm_heating_circuit_2_flow_sensor:
+      name: "HC2 Flow Sensor Alarm"
+  #Other stuff
+    load_pump_running:
+      name: "Loading Pump Operational"
+    circulation_pump_running:
+      name: "Circulation Pump Operational"
+    solar_pump_lowering:
+      name: "Solar Pump Lowering"
+
+
+
+
+output:
+  - platform: gpio
+    id: led3
+    #name: LED3_Yellow
+    pin: 
+      number: 23
+      mode: OUTPUT
+      inverted: true
+  - platform: gpio
+    id: led4
+    #name: LED4_Red
+    pin: 
+      number: 25
+      mode: OUTPUT
+      inverted: true
+
+button:
+  - platform: restart
+    name: "KM271-WiFi Restart"
+  - platform: template
+    name: "KM271 WW-Bereitung Aus"
+    on_press:
+      - lambda:
+          uint8_t command[] = {0x0C, 0x0E, 0x00, 0x65, 0x65, 0x65, 0x65, 0x65};
+          budoil->writer.enqueueTelegram(command, 8);
+  - platform: template
+    name: "KM271 WW-Bereitung Ein"
+    on_press:
+      - lambda:
+          uint8_t command[] = {0x0C, 0x0E, 0x01, 0x65, 0x65, 0x65, 0x65, 0x65};
+          budoil->writer.enqueueTelegram(command, 8);
+  - platform: template
+    name: "KM271 WW-Bereitung Auto"
+    on_press:
+      - lambda:
+          uint8_t command[] = {0x0C, 0x0E, 0x02, 0x65, 0x65, 0x65, 0x65, 0x65};
+          budoil->writer.enqueueTelegram(command, 8);
+
+
+number:
+  - platform: km271_wifi
+    config_ww_temperature:
+      name: "Hot Water Temperature Day"
+      mode: slider
+    config_frost_switch_temperature:
+      name: "Frost Switching Temperature"
+      mode: slider
+
+    config_heating_circuit_1_room_target_temperature_night:
+      name: "HC1 Target Room Temperature Night"
+      mode: slider
+    config_heating_circuit_1_room_target_temperature_day:
+      name: "HC1 Target Room Temperature Day"
+      mode: slider
+    config_heating_circuit_1_holiday_target_temperature:
+      name: "Holiday Temperature"
+      mode: slider
+    config_heating_circuit_1_flow_temperature_max:
+      name: "HC1 Maximum Heating Circuit Temperature"
+      mode: slider
+    config_heating_circuit_1_design_temperature:
+      name: "HC1 Design Temperature"
+      mode: slider
+    config_heating_circuit_1_room_temperature_offset:
+      name: "HC1 Room Temperature Offset"
+      mode: slider
+    config_heating_circuit_1_holiday_days:
+      name: "HC1 Holiday Days"
+      mode: slider
+
+    config_heating_circuit_2_room_target_temperature_night:
+      name: "HC2 Target Room Temperature Night"
+      mode: slider
+    config_heating_circuit_2_room_target_temperature_day:
+      name: "HC2 Target Room Temperature Day"
+      mode: slider
+    config_heating_circuit_2_holiday_target_temperature:
+      name: "Holiday Temperaturer"
+      mode: slider
+    config_heating_circuit_2_flow_temperature_max:
+      name: "HC2 Maximum Heating Circuit Temperature"
+      mode: slider
+    config_heating_circuit_2_design_temperature:
+      name: "HC2 Design Temperature"
+      mode: slider
+    config_heating_circuit_2_room_temperature_offset:
+      name: "HC2 Room Temperature Offset"
+      mode: slider
+    config_heating_circuit_2_holiday_days:
+      name: "HC2 Holiday Day"
+      mode: slider
+
+select:
+  - platform: km271_wifi
+    config_ww_operation_mode:
+      name: "Hot Water Operating Mode"
+    config_ww_circular_pump_interval:
+      name: "WHot Water Circulation Pump Interval"
+
+    config_heating_circuit_1_summer_winter_switch_temperature:
+      name: "HC1 Summer Winter Changeover Temperature"
+    config_heating_circuit_1_operation_mode:
+      name: "HC1 Operation Mode"
+    config_heating_circuit_1_lowering_type:
+      name: "HC1 Lowering Type"
+    config_heating_circuit_1_heating_system_type:
+      name: "HC1 Heating System"
+    config_heating_circuit_1_heating_program:
+      name: "HC1 Heating Program"
+
+    config_heating_circuit_2_summer_winter_switch_temperature:
+      name: "HC2 Summer Winter Changeover Temperature"
+    config_heating_circuit_2_operation_mode:
+      name: "HC2 Operation Mode"
+    config_heating_circuit_2_lowering_type:
+      name: "HC2 Lowering Type"
+    config_heating_circuit_2_heating_system_type:
+      name: "HC2 Heating System"
+    config_heating_circuit_2_heating_program:
+      name: "HC2 Heating Program"
+
+sensor:
+  - platform: km271_wifi
+    heating_circuit_1_flow_target_temperature:
+      name: "HC1 Target Flow Temperature"
+    heating_circuit_1_flow_temperature:
+      name: "HC1 Flow Temperature"
+    heating_circuit_1_room_target_temperature:
+      name: "HC1 Target Room Temperature"
+    heating_circuit_1_room_temperature:
+      name: "HC1 Actual Room Temperature"
+    heating_circuit_1_pump_power:
+      name: "HC1 Pump Power"
+    heating_circuit_1_mixer_position:
+      name: "HC1 Mixer Position"
+    heating_circuit_1_curve_p10:
+      name: "HC1 Heating Curve +10 °C"
+    heating_circuit_1_curve_0:
+      name: "HC1 Heating Curve 0 °C"
+    heating_circuit_1_curve_n10:
+      name: "HC1 Heating Curve -10 °C"
+    heating_circuit_2_flow_target_temperature:
+      name: "HC2 Target Flow Temperature"
+    heating_circuit_2_flow_temperature:
+      name: "HC2 Flow Temperature"
+    heating_circuit_2_room_target_temperature:
+      name: "HC2 Target Room Temperature"
+    heating_circuit_2_room_temperature:
+      name: "HC2 Actual Room Temperature"
+    heating_circuit_2_pump_power:
+      name: "HC2 Pump Power"
+    heating_circuit_2_mixer_position:
+      name: "HC2 Mixer Position"
+    heating_circuit_2_curve_p10:
+      name: "HC2 Heating Curve +10 °C"
+    heating_circuit_2_curve_0:
+      name: "HC2 Heating Curve 0 °C"
+    heating_circuit_2_curve_n10:
+      name: "HC2 Heating Curve -10 °C"
+    ww_target_temperature:
+      name: "Hot Water Target Temperature"
+    ww_temperature:
+      name: "Actual Hot Water temperature"
+    boiler_target_temperature:
+      name: "Boiler Target Temperature"
+    boiler_temperature:
+      name: "Boiler Actual Temperature"
+    boiler_turn_on_temperature:
+      name: "Burner Switch-on Temperature"
+    boiler_turn_off_temperature:
+      name: "Burner Switch-off Temperature"
+    exhaust_gas_temperature:
+      name: "Exhaust Gas Temperature"
+    outdoor_temperature:
+      name: "Outside Temperature"
+    attenuated_outdoor_temperature:
+      name: "Attenuated Outdoor Temperature"
+    boiler_runtime_1:
+      name: "Burner Runtime 1"
+    boiler_runtime_2:
+      name: "Burner Runtime 2"
+
+  - platform: wifi_signal
+    name: "KM217 WiFi Signal Sensor"
+    update_interval: 60s
+
+  - platform: adc
+    pin: 36
+    unit_of_measurement: "V"
+    name: "KM217 5V Supply"
+    accuracy_decimals: 2
+    update_interval: 5s
+    attenuation: 6dB
+    filters:
+      - multiply: 28.1826
+      - throttle_average: 60s
+      
+switch:
+  - platform: gpio
+    name: LED2_Green
+    pin: 
+      number: 22
+      mode: OUTPUT
+      inverted: true
+
+text_sensor:
+  - platform: km271_wifi
+    firmware_version:
+      name: "Firmware Version Control"


### PR DESCRIPTION
Since improv has problems with km271 I removed it from the default config to save some space.
The captive portal and fallback hotspot are the way to go to set WiFi credentials