### PR TITLE
chore(deps): batch-integrate open Renovate PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,12 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v7.0.1
       - name: ESPHome ${{ matrix.esphome-version }}
-        uses: esphome/build-action@v7.1.0
+        uses: esphome/build-action@v8.0.0
         with:
           yaml-file: ${{ matrix.file }}.yaml
           version: ${{ matrix.esphome-version }}
       - name: ESPHome ${{ matrix.esphome-version }} Factory
-        uses: esphome/build-action@v7.1.0
+        uses: esphome/build-action@v8.0.0
         with:
           yaml-file: ${{ matrix.file }}.factory.yaml
           version: ${{ matrix.esphome-version }}

--- a/.github/workflows/publish-firmware.yml
+++ b/.github/workflows/publish-firmware.yml
@@ -43,7 +43,7 @@ jobs:
   build-firmware:
     name: Build Firmware
     needs: set-release-version
-    uses: esphome/workflows/.github/workflows/build.yml@2025.10.0
+    uses: esphome/workflows/.github/workflows/build.yml@2026.8.1
     with:
       files: |
         buderus-km271_en_espidf.factory.yaml
@@ -58,6 +58,6 @@ jobs:
     needs:
       - build-firmware
       - set-release-version
-    uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@2025.10.0
+    uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@2026.8.1
     with:
       version: ${{ needs.set-release-version.outputs.release_version }}

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -39,7 +39,7 @@ jobs:
           destination: ./output
 
       - name: Fetch firmware files
-        uses: robinraju/release-downloader@v1.12
+        uses: robinraju/release-downloader@v1.13
         with:
           latest: true
           fileName: '*'

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -65,7 +65,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Setup Pages
-        uses: actions/configure-pages@v5.0.0
+        uses: actions/configure-pages@v6.0.0
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -69,4 +69,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4.0.5
+        uses: actions/deploy-pages@v5.0.0

--- a/.github/workflows/semantic_release.yaml
+++ b/.github/workflows/semantic_release.yaml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.check.outputs.release == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.semver.outputs.version }}
           name: Release v${{ steps.semver.outputs.version }}

--- a/buderus-km271-renovate-trigger.yaml
+++ b/buderus-km271-renovate-trigger.yaml
@@ -6,5 +6,5 @@
 
 # Use a fixed version for testing Renovate
 external_components:
-  - source: github://the78mole/esphome_components@v1.0.36
+  - source: github://the78mole/esphome_components@v1.0.48
     components: [ km271_wifi ]


### PR DESCRIPTION
Bündelt alle offenen Renovate-PRs in einen Merge, damit nur ein Semantic-Release-/Firmware-Publish-Lauf ausgelöst wird (`semantic_release.yaml` hat keine `concurrency`-Gruppe, sieben Einzel-Merges würden parallel um dasselbe Tag konkurrieren).

Enthalten:

| PR | Update |
|----|--------|
| #67 | `esphome/build-action` v7.1.0 → v8.0.0 |
| #68 | `softprops/action-gh-release` v2 → v3 |
| #61 | `robinraju/release-downloader` v1.12 → v1.13 |
| #62 | `actions/configure-pages` v5.0.0 → v6.0.0 |
| #63 | `actions/deploy-pages` v4.0.5 → v5.0.0 |
| #65 | `esphome/workflows` 2025.10.0 → 2026.8.1 (build + upload) |
| #52 | `the78mole/esphome_components` v1.0.36 → v1.0.48 |

Nicht enthalten: #59 (`esphome/build-action` v7.4.0) — durch #67 überholt, wird geschlossen.

Prüfung der Major-Bumps:
- gh-release v3, configure-pages v6, deploy-pages v5 sind reine Node-20→Node-24-Runtime-Umstellungen, keine Input-/Output-Änderungen.
- `esphome/workflows` 2026.8.1 ändert das Artefakt-Layout (`<artifact-name>/<version>/` statt `<version>/`, wegen `download-artifact` v5+). `build.yml` und `upload-to-gh-release.yml` sind dadurch gekoppelt und werden hier gemeinsam gebumpt — die Workflow-Inputs bleiben unverändert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)